### PR TITLE
FO-2032 - src/ Add get stomp error message helper

### DIFF
--- a/src/iotics/host/api/follow_api.py
+++ b/src/iotics/host/api/follow_api.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from functools import partial
 from typing import Callable, Optional, Tuple
@@ -10,7 +9,7 @@ from retry import retry
 from stomp import ConnectionListener
 from stomp.exception import StompException
 
-from iotics.host.api.utils import deserialize
+from iotics.host.api.utils import deserialize, get_stomp_error_message
 from iotics.host.auth import AgentAuth
 from iotics.host.conf.base import DataSourcesConfBase
 from iotics.host.exceptions import DataSourcesStompError, DataSourcesStompNotConnected
@@ -67,7 +66,7 @@ class FollowStompListener(ConnectionListener):
         logging.error('Received stomp error body: %s headers: %s', body, headers)
         try:
             # This will be improved once https://ioticlabs.atlassian.net/browse/FO-1889 will be done
-            error = json.loads(body).get('error', 'No error body')
+            error = get_stomp_error_message(body) or 'No error body'
             if error in (
                     'UNAUTHENTICATED: token expired', 'The connection frame does not contain valid credentials.'
             ):

--- a/src/iotics/host/api/search_api.py
+++ b/src/iotics/host/api/search_api.py
@@ -15,7 +15,7 @@ from retry import retry
 from stomp import ConnectionListener
 from stomp.exception import StompException
 
-from iotics.host.api.utils import deserialize, ListOrTuple, sanitize_for_serialization
+from iotics.host.api.utils import deserialize, ListOrTuple, sanitize_for_serialization, get_stomp_error_message
 from iotics.host.auth import AgentAuth
 from iotics.host.conf.base import DataSourcesConfBase
 from iotics.host.exceptions import DataSourcesQApiError, DataSourcesSearchTimeout, DataSourcesStompError, \
@@ -76,7 +76,7 @@ class SearchStompListener(ConnectionListener):
         logger.error('Received search stomp error body: %s headers: %s', body, headers)
         try:
             # This will be improved once https://ioticlabs.atlassian.net/browse/FO-1889 will be done
-            error = json.loads(body).get('error', 'No error body')
+            error = get_stomp_error_message(body) or 'No error body'
             if error in (
                     'UNAUTHENTICATED: token expired', 'The connection frame does not contain valid credentials.'
             ):

--- a/src/iotics/host/api/utils.py
+++ b/src/iotics/host/api/utils.py
@@ -1,14 +1,13 @@
-from collections import namedtuple
 import contextlib
+import json
+from collections import namedtuple
 from functools import wraps
 from http import HTTPStatus
 from typing import List, T, Tuple, Union
 
 from shortuuid import uuid
-from iotic.web.rest.client.qapi import ApiClient, ApiException
+from iotic.web.rest.client.qapi import ApiClient, ApiException, RpcStatus
 from iotics.host.exceptions import DataSourcesQApiError, DataSourcesQApiHttpError
-
-
 ListOrTuple = Union[List[T], Tuple[T, ...]]
 
 
@@ -61,3 +60,12 @@ def deserialize(body, response_type):
 
 def sanitize_for_serialization(payload):
     return _API_CLIENT.sanitize_for_serialization(payload)
+
+
+def get_stomp_error_message(error_body: str) -> str:
+    # Compatibility with host before version 2.0.386
+    error = json.loads(error_body).get('error')
+    if error:
+        return error
+    rpc_status = _API_CLIENT.deserialize(Resp(error_body), RpcStatus)
+    return rpc_status.message

--- a/src/tests/iotics/data/test_utils.py
+++ b/src/tests/iotics/data/test_utils.py
@@ -1,0 +1,25 @@
+import json
+
+from iotic.web.rest.client.qapi import RpcStatus
+
+from iotics.host.api.utils import get_stomp_error_message
+
+
+def test_should_get_stomp_error_from_error_field():
+    error_body = {
+        'error': 'a stomp error',
+        'details': 'some details'
+    }
+    stomp_error_message = get_stomp_error_message(json.dumps(error_body))
+    assert stomp_error_message == error_body['error']
+
+
+def test_should_get_stomp_error_from_rpc_status():
+    rpc_status = RpcStatus(code=12, details='some details', message='a stomp error')
+    stomp_error_message = get_stomp_error_message(json.dumps(rpc_status.to_dict()))
+    assert stomp_error_message == rpc_status.message
+
+
+def test_get_stomp_error_message_should_return_none_if_no_message():
+    stomp_error_message = get_stomp_error_message('{}')
+    assert not stomp_error_message


### PR DESCRIPTION
- Hosts pre version 2.0.386 (excluded) return the stomp error message in the error field
- Hosts post version 2.0.386 (included) return the stomp error as a proper RpcStatus
- Kept place holders with a ref to FO-1889 for a future update using the status code if needed