### PR TITLE
EG-194 Update follow and search APIs to reconnect after a host restart

### DIFF
--- a/src/iotics/host/api/follow_api.py
+++ b/src/iotics/host/api/follow_api.py
@@ -103,6 +103,7 @@ class FollowAPI:
         except Exception as ex:
             raise DataSourcesStompNotConnected(ex) from ex
 
+    @retry(exceptions=ConnectionError, delay=1, backoff=10, max_delay=3600)
     def _connect(self, reconnect_attempts_max: int, heartbeats: Tuple[int, int]):
         """this method also used to handle reconnecting to stomp server if e.g. network connection goes down
         """

--- a/src/iotics/host/api/search_api.py
+++ b/src/iotics/host/api/search_api.py
@@ -135,6 +135,7 @@ class SearchAPI:
         except Exception as ex:
             raise DataSourcesStompNotConnected(ex) from ex
 
+    @retry(exceptions=ConnectionError, delay=1, backoff=10, max_delay=3600)
     def _connect(self, reconnect_attempts_max: int, heartbeats: Tuple[int, int]):
         """also used to handle reconnecting to stomp server if e.g. network connection goes down
         """

--- a/src/tests/iotics/data/test_search_api.py
+++ b/src/tests/iotics/data/test_search_api.py
@@ -3,6 +3,7 @@ import logging
 from unittest.mock import MagicMock, patch
 
 import pytest
+import retry
 from stomp.exception import NotConnectedException
 
 from iotics.host.api.qapi import QApiFactory
@@ -143,8 +144,11 @@ def test_api_disconnect_reconnect(mock_connected_api):
     # OSError - raised if tests are run in a Docker container:
     # https://medium.com/it-dead-inside/docker-containers-and-localhost-cannot-assign-requested-address-6ac7bc0d042b
     with pytest.raises(DataSourcesStompNotConnected):
-        # Tries to reconnect and raises an error since no real connection is set.
-        api.listener.on_disconnected()
+        # Ignore retry functionality.
+        with patch.object(retry.api, '__retry_internal', lambda f, *args, **kwargs: f()):
+            # Tries to reconnect and raises an error since no real connection is set.
+            api.listener.on_disconnected()
+
     api.disconnect()
     assert not api.active
     # Once disconnected it should not try to reconnect (should not raise the ConnectionRefusedError).


### PR DESCRIPTION
Commit message:
```
EG-194 Update follow and search APIs to reconnect after a host restart

* Add retry functionality to `_connect` methods that will be triggered after:
  1 second, 10 seconds, 1m40s, 16m40s and then indefinitely every 1h.
```
